### PR TITLE
Update class-and-style.md

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -22,7 +22,7 @@ You can have multiple classes toggled by having more fields in the object. In ad
 
 ``` html
 <div class="static"
-     v-bind:class="{ active: isActive, 'text-danger': hasError }">
+     v-bind:class="{ 'active': isActive, 'text-danger': hasError }">
 </div>
 ```
 


### PR DESCRIPTION
I know this a really small thing but I actually find it a bit confusing. 

I do realize `v-bind:class="{ active: isActive, 'text-danger': hasError }"` is valid syntax. 

But if you actually try `v-bind:class="{ 'active': isActive, text-danger: hasError }"`

You will get this error: `invalid expression: v-bind:class="{ 'active': isActive, text-danger: hasError }"`

So I guess just to make a bit more consistent with the other examples and avoid that error, I would propose having both as strings :).